### PR TITLE
Distinguish a Cloudflare origin failure from a bad Access cookie

### DIFF
--- a/src/dremio_client/cli.py
+++ b/src/dremio_client/cli.py
@@ -3,6 +3,7 @@
 import base64
 import datetime as dt
 import json
+import re
 import time
 from collections.abc import Iterator
 from pathlib import Path
@@ -39,6 +40,23 @@ def _json_or_die(r: requests.Response, what: str) -> Any:
     """Parse a lakehouse response, turning each failure mode into a plain message."""
     ctype = r.headers.get("content-type", "").split(";")[0].strip()
     if ctype == "text/html":
+        # HTML alone does not mean the cookie is bad. Cloudflare serves the Access
+        # sign-in page with HTTP 200, but it also serves its OWN error pages as HTML
+        # when it cannot reach the origin. Collapsing both into "refresh your cookie"
+        # is a wrong answer that costs a browser trip and fixes nothing.
+        #
+        # Measured 2026-08-11: HTTP 500, "500 Proxy Error ... Error during SSL
+        # Handshake with remote server", cf-mitigated absent, with a cookie that had
+        # 18.4 days left and that Cloudflare accepted. A JGI-side outage, not us.
+        if r.status_code >= 500:
+            m = re.search(r"Reason:\s*<strong>([^<]+)</strong>", r.text or "")
+            reason = f"\nCloudflare said: {m.group(1).strip()}" if m else ""
+            raise click.ClickException(
+                f"{what}: Cloudflare returned its own error page (HTTP {r.status_code}), which "
+                f"means it could not reach the Dremio origin.{reason}\n"
+                f"This is a lakehouse-side outage. {COOKIE_NAME} is not implicated, so do not "
+                f"refresh it. Retry later; raise it with JGI if it persists."
+            )
         raise click.ClickException(
             f"{what}: Cloudflare returned an HTML sign-in page (HTTP {r.status_code}), so the "
             f"request never reached Dremio.\n"

--- a/src/dremio_client/cli.py
+++ b/src/dremio_client/cli.py
@@ -53,8 +53,7 @@ def _json_or_die(r: requests.Response, what: str) -> Any:
             # bare text after the label so a markup change costs the detail line rather than
             # the whole diagnosis.
             body = r.text or ""
-            m = (re.search(r"Reason:\s*<strong>([^<]+)</strong>", body)
-                 or re.search(r"Reason:\s*([^<\n]{3,120})", body))
+            m = re.search(r"Reason:\s*<strong>([^<]+)</strong>", body) or re.search(r"Reason:\s*([^<\n]{3,120})", body)
             reason = f"\nUpstream reason: {m.group(1).strip()}" if m else ""
             raise click.ClickException(
                 f"{what}: HTTP {r.status_code} with HTML, which is an error page rather than the "

--- a/src/dremio_client/cli.py
+++ b/src/dremio_client/cli.py
@@ -49,13 +49,19 @@ def _json_or_die(r: requests.Response, what: str) -> Any:
         # Handshake with remote server", cf-mitigated absent, with a cookie that had
         # 18.4 days left and that Cloudflare accepted. A JGI-side outage, not us.
         if r.status_code >= 500:
-            m = re.search(r"Reason:\s*<strong>([^<]+)</strong>", r.text or "")
-            reason = f"\nCloudflare said: {m.group(1).strip()}" if m else ""
+            # The 2026-08-11 page wrapped it as `Reason: <strong>...</strong>`. Fall back to
+            # bare text after the label so a markup change costs the detail line rather than
+            # the whole diagnosis.
+            body = r.text or ""
+            m = (re.search(r"Reason:\s*<strong>([^<]+)</strong>", body)
+                 or re.search(r"Reason:\s*([^<\n]{3,120})", body))
+            reason = f"\nUpstream reason: {m.group(1).strip()}" if m else ""
             raise click.ClickException(
-                f"{what}: Cloudflare returned its own error page (HTTP {r.status_code}), which "
-                f"means it could not reach the Dremio origin.{reason}\n"
-                f"This is a lakehouse-side outage. {COOKIE_NAME} is not implicated, so do not "
-                f"refresh it. Retry later; raise it with JGI if it persists."
+                f"{what}: HTTP {r.status_code} with HTML, which is an error page rather than the "
+                f"Access sign-in page.{reason}\n"
+                f"That usually means the edge could not reach the Dremio origin, so check whether "
+                f"the service is up before refreshing {COOKIE_NAME}. Retry later; raise it with "
+                f"JGI if it persists."
             )
         raise click.ClickException(
             f"{what}: Cloudflare returned an HTML sign-in page (HTTP {r.status_code}), so the "


### PR DESCRIPTION
While checking whether the JGI lakehouse was queryable without the VPN, `dremio login` reported:

```
CF_Authorization   valid for 18.4 more days (2026-08-29 21:17 EDT)
Error: Dremio login: Cloudflare returned an HTML sign-in page (HTTP 500), so the request never reached Dremio.
CF_Authorization is missing, expired or revoked. Refresh it from the browser...
```

Two consecutive lines contradicting each other, and the advice was wrong.

`_json_or_die` branched on content-type alone. The comment above it correctly documents that a cookie-less request returns HTTP **200** with an Access sign-in page, but the check never looked at the status code, so Cloudflare's own 5xx error pages were also read as an auth failure.

Measured directly on 2026-08-11:

```
HTTP 500   type=text/html   server=cloudflare   cf-mitigated=None
<title>500 Proxy Error</title>
Reason: Error during SSL Handshake with remote server
```

`cf-mitigated` absent means Cloudflare did not challenge or block the request, so the cookie was accepted and passed through. Cloudflare simply could not complete TLS to the Dremio origin. A JGI-side outage that no credential change can fix.

Now:

- **5xx plus HTML** reports an origin failure, surfaces Cloudflare's own `Reason` string, and says explicitly not to refresh the cookie
- **sub-500 plus HTML** keeps the original sign-in message

Verified against the live outage:

```
Error: Dremio login: Cloudflare returned its own error page (HTTP 500), which means it could not reach the Dremio origin.
Cloudflare said: Error during SSL Handshake with remote server
This is a lakehouse-side outage. CF_Authorization is not implicated, so do not refresh it. Retry later; raise it with JGI if it persists.
```

`labctl status jgi-dremio` in turbomam/bin reports the same wrong diagnosis and will need the equivalent change.